### PR TITLE
Generate markdown on build without links

### DIFF
--- a/.azuredevops/Pipelines/build.yaml
+++ b/.azuredevops/Pipelines/build.yaml
@@ -100,6 +100,13 @@ stages:
             errorActionPreference: 'silentlyContinue'
             ignoreLASTEXITCODE: true
 
+        # regenerate markdowns without links (in order to generate markdown to be included in nuget package)
+        - pwsh: |
+            dotnet tool install --tool-path . MarkdownSnippets.Tool
+            ./mdsnippets --omit-snippet-links true
+          displayName: Re-generate markdown without links
+          name: mdsnippets
+
         - task: DotNetCoreCLI@2
           displayName: DotNet Restore
           inputs:

--- a/src/ImageHash/PackageDescription.md
+++ b/src/ImageHash/PackageDescription.md
@@ -1,47 +1,15 @@
 # ImageHash
 
-Perceptual image hashing in netstandard using the ImageSharp library. Includes three hashing algorithms (AverageHash, DifferenceHash, and PerceptualHash).
+Perceptual image hashing using the ImageSharp library. Includes three hashing algorithms (AverageHash, DifferenceHash, and PerceptualHash).
+See [github](https://www.github.com/coenmm/ImageHash/) for more information.
 
 ## Calculate image hash
 
 <!-- snippet: CalculateImageHash -->
-<a id='snippet-calculateimagehash'></a>
-```cs
-var hashAlgorithm = new AverageHash();
-// or one of the other available algorithms:
-// var hashAlgorithm = new DifferenceHash();
-// var hashAlgorithm = new PerceptualHash();
-
-string filename = "your filename";
-using var stream = File.OpenRead(filename);
-
-ulong imageHash = hashAlgorithm.Hash(stream);
-```
-<sup><a href='/tests/ImageHash.Test/Examples.cs#L14-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-calculateimagehash' title='Start of snippet'>anchor</a></sup>
-<!-- endSnippet -->
-
-### Calculate image similarity
-Note that to calculate the image similarity, both image hashes should have been calculated using the same hash algorihm.
-
-<!-- snippet: CalculateSimilarity -->
-<a id='snippet-calculatesimilarity'></a>
-```cs
-// calculate the two image hashes
-ulong hash1 = hashAlgorithm.Hash(imageStream1);
-ulong hash2 = hashAlgorithm.Hash(imageStream2);
-
-double percentageImageSimilarity = CompareHash.Similarity(hash1, hash2);
-```
-<sup><a href='/tests/ImageHash.Test/Examples.cs#L35-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-calculatesimilarity' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Calculate image similarity
 Note that to calculate the image similarity, both image hashes should have been calculated using the same hash algorihm.
 
-```cs
-// calculate the two image hashes
-ulong hash1 = hashAlgorithm.Hash(imageStream1);
-ulong hash2 = hashAlgorithm.Hash(imageStream2);
-
-double percentageImageSimilarity = CompareHash.Similarity(hash1, hash2);
-```
+<!-- snippet: CalculateSimilarity -->
+<!-- endSnippet -->

--- a/src/ImageHash/PackageDescription.md
+++ b/src/ImageHash/PackageDescription.md
@@ -1,7 +1,7 @@
 # ImageHash
 
 Perceptual image hashing using the ImageSharp library. Includes three hashing algorithms (AverageHash, DifferenceHash, and PerceptualHash).
-See [github](https://www.github.com/coenmm/ImageHash/) for more information.
+See [github](https://www.github.com/coenm/ImageHash/) for more information.
 
 ## Calculate image hash
 

--- a/src/ImageHash/PackageDescription.md
+++ b/src/ImageHash/PackageDescription.md
@@ -6,10 +6,32 @@ See [github](https://www.github.com/coenmm/ImageHash/) for more information.
 ## Calculate image hash
 
 <!-- snippet: CalculateImageHash -->
+<a id='snippet-calculateimagehash'></a>
+```cs
+var hashAlgorithm = new AverageHash();
+// or one of the other available algorithms:
+// var hashAlgorithm = new DifferenceHash();
+// var hashAlgorithm = new PerceptualHash();
+
+string filename = "your filename";
+using var stream = File.OpenRead(filename);
+
+ulong imageHash = hashAlgorithm.Hash(stream);
+```
+<sup><a href='/tests/ImageHash.Test/Examples.cs#L14-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-calculateimagehash' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->
 
 ## Calculate image similarity
 Note that to calculate the image similarity, both image hashes should have been calculated using the same hash algorihm.
 
 <!-- snippet: CalculateSimilarity -->
+<a id='snippet-calculatesimilarity'></a>
+```cs
+// calculate the two image hashes
+ulong hash1 = hashAlgorithm.Hash(imageStream1);
+ulong hash2 = hashAlgorithm.Hash(imageStream2);
+
+double percentageImageSimilarity = CompareHash.Similarity(hash1, hash2);
+```
+<sup><a href='/tests/ImageHash.Test/Examples.cs#L35-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-calculatesimilarity' title='Start of snippet'>anchor</a></sup>
 <!-- endSnippet -->

--- a/src/ImageHash/PackageDescription.md
+++ b/src/ImageHash/PackageDescription.md
@@ -4,6 +4,8 @@ Perceptual image hashing in netstandard using the ImageSharp library. Includes t
 
 ## Calculate image hash
 
+<!-- snippet: CalculateImageHash -->
+<a id='snippet-calculateimagehash'></a>
 ```cs
 var hashAlgorithm = new AverageHash();
 // or one of the other available algorithms:
@@ -15,6 +17,23 @@ using var stream = File.OpenRead(filename);
 
 ulong imageHash = hashAlgorithm.Hash(stream);
 ```
+<sup><a href='/tests/ImageHash.Test/Examples.cs#L14-L26' title='Snippet source file'>snippet source</a> | <a href='#snippet-calculateimagehash' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
+
+### Calculate image similarity
+Note that to calculate the image similarity, both image hashes should have been calculated using the same hash algorihm.
+
+<!-- snippet: CalculateSimilarity -->
+<a id='snippet-calculatesimilarity'></a>
+```cs
+// calculate the two image hashes
+ulong hash1 = hashAlgorithm.Hash(imageStream1);
+ulong hash2 = hashAlgorithm.Hash(imageStream2);
+
+double percentageImageSimilarity = CompareHash.Similarity(hash1, hash2);
+```
+<sup><a href='/tests/ImageHash.Test/Examples.cs#L35-L43' title='Snippet source file'>snippet source</a> | <a href='#snippet-calculatesimilarity' title='Start of snippet'>anchor</a></sup>
+<!-- endSnippet -->
 
 ## Calculate image similarity
 Note that to calculate the image similarity, both image hashes should have been calculated using the same hash algorihm.


### PR DESCRIPTION
Use the `MarkdownSnippets.Tool` to (re-)generate documentation (markdown files) without links in devops. 

This will re-generate the `PackageDescription.md` which is used in the nuget artiface.  Nuget.org doesn't allow the README file to have html content.