### PR TITLE
Update SixLabors.ImageSharp to 2.1.9

### DIFF
--- a/build/Packages.targets
+++ b/build/Packages.targets
@@ -14,7 +14,7 @@
   <ItemGroup>
 
     <!--Dependencies production code (and maybe also in test code)-->
-    <PackageReference Update="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Update="SixLabors.ImageSharp" Version="2.1.9" />
 
     <!-- Packages and tools for releasing (sourcelink)-->
     <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />


### PR DESCRIPTION
Update SixLabors.ImageSharp to 2.1.9. This pulls in a fix for [CVE-2024-41131](https://nvd.nist.gov/vuln/detail/cve-2024-41131)

Here are the release notes for version 2.1.9, for reference: https://github.com/SixLabors/ImageSharp/releases/tag/v2.1.9

I didn't see a way to run CI/CD, but let me know if I can kick one off somehow and I'd be happy to do so. Tested on my machine:

- [x] compiles
- [x] tests pass